### PR TITLE
Use dynamic column widths for list and cleanup output

### DIFF
--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -146,8 +146,23 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	out := cmd.OutOrStdout()
 	_, _ = fmt.Fprintln(out, "Worktrees eligible for cleanup:")
 	_, _ = fmt.Fprintln(out)
+
+	// Calculate column widths based on content
+	nameWidth := len("NAME")
+	branchWidth := len("BRANCH")
 	for _, c := range candidates {
-		_, _ = fmt.Fprintf(out, "  %-20s  %-30s  (%s)\n", c.name, c.branch, c.reason)
+		if len(c.name) > nameWidth {
+			nameWidth = len(c.name)
+		}
+		if len(c.branch) > branchWidth {
+			branchWidth = len(c.branch)
+		}
+	}
+
+	// Print header and rows with dynamic widths
+	_, _ = fmt.Fprintf(out, "  %-*s  %-*s  %s\n", nameWidth, "NAME", branchWidth, "BRANCH", "STATUS")
+	for _, c := range candidates {
+		_, _ = fmt.Fprintf(out, "  %-*s  %-*s  [%s]\n", nameWidth, c.name, branchWidth, c.branch, c.reason)
 	}
 	_, _ = fmt.Fprintln(out)
 

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -178,10 +178,24 @@ func formatCompactStatus(status *git.WorktreeStatus) string {
 // printCompactWorktrees prints worktrees in compact table format
 func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo) {
 	out := cmd.OutOrStdout()
-	_, _ = fmt.Fprintf(out, "  %-20s  %-30s %s\n", "NAME", "BRANCH", "STATUS")
+
+	// Calculate column widths based on content
+	nameWidth := len("NAME")
+	branchWidth := len("BRANCH")
+	for _, wt := range worktrees {
+		if len(wt.name) > nameWidth {
+			nameWidth = len(wt.name)
+		}
+		if len(wt.branch) > branchWidth {
+			branchWidth = len(wt.branch)
+		}
+	}
+
+	// Print header and rows with dynamic widths
+	_, _ = fmt.Fprintf(out, "  %-*s  %-*s  %s\n", nameWidth, "NAME", branchWidth, "BRANCH", "STATUS")
 	for _, wt := range worktrees {
 		statusStr := formatCompactStatus(wt.status)
-		_, _ = fmt.Fprintf(out, "%s%-20s  %-30s %s\n", wt.currentMarker, wt.name, wt.branch, statusStr)
+		_, _ = fmt.Fprintf(out, "%s%-*s  %-*s  %s\n", wt.currentMarker, nameWidth, wt.name, branchWidth, wt.branch, statusStr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Calculate column widths dynamically based on actual content to handle long worktree and branch names without breaking table alignment
- Add header row to cleanup output (`NAME`, `BRANCH`, `STATUS`) matching list format
- Change cleanup status from parentheses `(merged into main)` to bracket format `[merged into main]` for consistency with list output

## Test plan
- [ ] Run `wt list` with worktrees that have long names/branches - verify columns align properly
- [ ] Run `wt cleanup --dry-run` - verify header row appears and status uses bracket format
- [ ] Run `make test` to verify all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table formatting in cleanup and list command outputs by implementing dynamic column width calculations that adapt to content
  * Enhanced column alignment and readability for NAME and BRANCH columns based on actual data
  * Refined status indicator display formatting for better visual presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->