### PR TITLE
Add Claude Code project permissions for safe command allowlisting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make build)",
+      "Bash(make test)",
+      "Bash(make lint)",
+      "Bash(make install)",
+      "Bash(make build-all)",
+      "Bash(make clean)",
+      "Bash(go test*)",
+      "Bash(go build*)",
+      "Bash(go mod tidy*)",
+      "Bash(go mod download*)",
+      "Bash(go mod verify*)",
+      "Bash(go vet*)",
+      "Bash(go fmt*)",
+      "Bash(golangci-lint run*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git branch --list*)",
+      "Bash(git branch -a*)",
+      "Bash(git branch -r*)",
+      "Bash(git show*)",
+      "Bash(git rev-parse*)",
+      "Bash(git ls-files*)",
+      "Bash(git worktree list*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr list*)",
+      "Bash(gh pr checks*)",
+      "Bash(gh pr diff*)",
+      "Bash(gh pr status*)",
+      "Bash(gh issue view*)",
+      "Bash(gh issue list*)",
+      "Bash(gh issue status*)",
+      "Bash(gh repo view*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with project-level permission allowlist
- Whitelist read-only and build operations to reduce permission prompts
- Intentionally exclude write operations and dangerous commands

## Allowlisted Commands
**Build/Test:** make targets, go test/build/mod/vet/fmt, golangci-lint

**Git (read-only):** status, diff, log, branch --list, show, rev-parse, ls-files, worktree list

**GitHub CLI (read-only):** pr view/list/checks/diff/status, issue view/list/status, repo view

## Intentionally Excluded
- `go run` - executes arbitrary code
- `gh api` - can make any API call
- Write operations for git branch, gh pr, gh issue, gh repo

## Test plan
- [ ] Verify Claude Code picks up the settings from the repo
- [ ] Test that allowlisted commands run without prompts
- [ ] Verify non-allowlisted commands still require approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration settings to establish permissions policies for automated build, testing, and deployment operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->