### PR TITLE
Store release notes in file for GitHub release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          body_path: RELEASE_NOTES.md
           files: |
             dist/*.tar.gz
             dist/checksums.txt

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -112,13 +112,17 @@ echo "New version: $NEW_VERSION"
 # Update VERSION file
 echo "$NEW_VERSION" > "$VERSION_FILE"
 
+# Write release notes to file for workflow to use
+RELEASE_NOTES_FILE="${REPO_ROOT}/RELEASE_NOTES.md"
+echo "$RELEASE_NOTES" > "$RELEASE_NOTES_FILE"
+
 # Commit, tag, and push
 cd "$REPO_ROOT"
 
-git add VERSION
+git add VERSION RELEASE_NOTES.md
 git commit -m "Bump version to ${NEW_VERSION}"
 
-git tag -a "v${NEW_VERSION}" -m "${RELEASE_NOTES}"
+git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
 
 echo ""
 echo "Pushing to origin main..."


### PR DESCRIPTION
## Summary
- Release notes are now written to `RELEASE_NOTES.md` by `release.sh`
- Workflow reads notes via `body_path` parameter, combining with auto-generated changelog
- Tag messages are now simple "Release vX.Y.Z" instead of containing full notes

## Test plan
- [x] Verified v0.1.0 release shows custom notes above auto-generated changelog
- [x] Verified v0.1.0 tag has simple annotation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to automatically manage release notes and standardize release tagging during the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->