### PR TITLE
Change directory to repo root when deleting current worktree

### DIFF
--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -189,6 +190,16 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Check if user is in any of the worktrees being deleted
+	cwd, _ := os.Getwd()
+	inDeletedWorktree := false
+	for _, c := range candidates {
+		if strings.HasPrefix(cwd, c.path) {
+			inDeletedWorktree = true
+			break
+		}
+	}
+
 	// Delete each candidate
 	var deleted int
 	for _, c := range candidates {
@@ -234,5 +245,11 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	}
 
 	cmd.Printf("Cleaned up %d worktree(s)\n", deleted)
+
+	// If user was in a deleted worktree, output repo root for shell wrapper to cd
+	if inDeletedWorktree && deleted > 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), repoRoot)
+	}
+
 	return nil
 }

--- a/internal/commands/delete.go
+++ b/internal/commands/delete.go
@@ -123,12 +123,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Warn if user is in the worktree being deleted
+	// Check if user is in the worktree being deleted
 	cwd, _ := os.Getwd()
-	if strings.HasPrefix(cwd, worktreePath) {
-		cmd.Println("Warning: You are currently in this worktree.")
-		cmd.Println("After deletion, run 'wt exit' or 'cd' to another directory.")
-	}
+	inDeletedWorktree := strings.HasPrefix(cwd, worktreePath)
 
 	// Run pre-delete hooks
 	if err := hooks.RunPreDelete(cfg, env); err != nil {
@@ -158,6 +155,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	cmd.Printf("Worktree %q deleted successfully\n", name)
+
+	// If user was in the deleted worktree, output repo root for shell wrapper to cd
+	if inDeletedWorktree {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), repoRoot)
+	}
+
 	return nil
 }
 

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -159,7 +159,7 @@ wt() {
 
   # Commands that need cd handling
   case "$1" in
-    create)
+    create|delete|cleanup)
       local output
       output=$(command wt "$@" 2>&1)
       local exit_code=$?
@@ -167,12 +167,13 @@ wt() {
       if [[ $exit_code -eq 0 ]]; then
         # Print all but last line
         echo "$output" | sed '$d'
-        # cd to path on last line
+        # cd to path on last line if it's a directory
         local target=$(echo "$output" | tail -1)
         if [[ -d "$target" ]]; then
           cd "$target"
         else
-          echo "$output"
+          # Last line wasn't a directory, print it too
+          echo "$target"
         fi
       else
         echo "$output"
@@ -347,7 +348,7 @@ wt() {
   fi
 
   case "$1" in
-    create)
+    create|delete|cleanup)
       local output
       output=$(command wt "$@" 2>&1)
       local exit_code=$?
@@ -358,7 +359,7 @@ wt() {
         if [[ -d "$target" ]]; then
           cd "$target"
         else
-          echo "$output"
+          echo "$target"
         fi
       else
         echo "$output"
@@ -497,7 +498,7 @@ function wt
   end
 
   switch $argv[1]
-    case create
+    case create delete cleanup
       set -l output (command wt $argv 2>&1)
       set -l exit_code $status
 
@@ -507,7 +508,7 @@ function wt
         if test -d "$target"
           cd "$target"
         else
-          echo "$output"
+          echo "$target"
         end
       else
         echo "$output"


### PR DESCRIPTION
## Summary
- When deleting a worktree that the user is currently in (`wt delete` or `wt cleanup`), automatically change to the repository root
- Previously users would be left in a deleted directory and had to manually run `wt exit` or `cd`

## Test plan
- [x] All existing tests pass
- [x] Linter passes
- [ ] Manual test: `wt create test-delete && wt delete` - should return to repo root
- [ ] Manual test: Create merged worktree, run `wt cleanup` from within it - should return to repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Improvements**
- Automatically navigate to the repository root when deleting the worktree you're currently in
- Enhanced shell wrapper support for delete and cleanup operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->