### PR TITLE
Allow Read, Glob, and Grep tools in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,9 @@
 {
   "permissions": {
     "allow": [
+      "Read(**)",
+      "Glob(**)",
+      "Grep(**)",
       "Bash(make build)",
       "Bash(make test)",
       "Bash(make lint)",


### PR DESCRIPTION
## Summary
- Add permissions for `Read(**)`, `Glob(**)`, and `Grep(**)` tools in Claude Code settings
- Uses `**` pattern to allow file reading and searching within the current directory tree
- Prevents Claude from getting stuck waiting for permission prompts during codebase exploration

## Test plan
- [ ] Verify Claude Code can read files without permission prompts
- [ ] Verify Glob/Grep searches work within the repo
- [ ] Confirm operations outside the repo still require permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded allowed operations in configuration settings to support additional Read, Glob, and Grep operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->