### PR TITLE
Fix cleanup command hanging due to unbuffered stdout

### DIFF
--- a/internal/commands/delete.go
+++ b/internal/commands/delete.go
@@ -171,6 +171,8 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 func confirmAction(prompt string) bool {
 	reader := bufio.NewReader(os.Stdin)
+	// Flush stdout to ensure all previous output is visible before prompting
+	_ = os.Stdout.Sync()
 	fmt.Printf("%s [y/N] ", prompt)
 	response, err := reader.ReadString('\n')
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix `wt cleanup` appearing to hang when prompting for user confirmation
- Add `os.Stdout.Sync()` before reading stdin to flush buffered output
- Users now see the worktree list before being asked to confirm deletion

## Test plan
- [x] Run `wt cleanup` with merged worktrees and verify output appears before the `[y/N]` prompt
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced output handling to guarantee all prior messages are visible before the system requests user input, improving overall interaction flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->