### PR TITLE
Add fetch_interval config to prevent repeated fetches

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -238,6 +238,27 @@ func UpdateRemoteHead(repoRoot, remote string) error {
 	return cmd.Run()
 }
 
+// GetLastFetchTime returns the time of the last fetch for a remote
+func GetLastFetchTime(repoRoot, remote string) (time.Time, error) {
+	fetchFile := filepath.Join(repoRoot, ".git", "wt-last-fetch-"+remote)
+	data, err := os.ReadFile(fetchFile)
+	if err != nil {
+		return time.Time{}, err
+	}
+	timestamp, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(timestamp, 0), nil
+}
+
+// SetLastFetchTime records the current time as the last fetch time for a remote
+func SetLastFetchTime(repoRoot, remote string) error {
+	fetchFile := filepath.Join(repoRoot, ".git", "wt-last-fetch-"+remote)
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	return os.WriteFile(fetchFile, []byte(timestamp+"\n"), 0644)
+}
+
 // GetDefaultBranch returns the default branch name (main or master)
 func GetDefaultBranch(repoRoot string) (string, error) {
 	// Try to get the default branch from remote

--- a/internal/userconfig/userconfig_test.go
+++ b/internal/userconfig/userconfig_test.go
@@ -254,11 +254,11 @@ func TestLoadNonexistent(t *testing.T) {
 
 func TestValidKeys(t *testing.T) {
 	keys := ValidKeys()
-	if len(keys) != 2 {
-		t.Errorf("expected 2 valid keys, got %d", len(keys))
+	if len(keys) != 3 {
+		t.Errorf("expected 3 valid keys, got %d", len(keys))
 	}
 
-	expected := map[string]bool{"remote": true, "fetch": true}
+	expected := map[string]bool{"remote": true, "fetch": true, "fetch_interval": true}
 	for _, key := range keys {
 		if !expected[key] {
 			t.Errorf("unexpected key: %s", key)


### PR DESCRIPTION
## Summary
- Adds `fetch_interval` config option to set minimum time between fetches (default: 5m)
- When a fetch was performed recently, commands skip fetching and print "Skipping fetch (last fetch Xs ago)"
- Last fetch time stored per-remote in `.git/wt-last-fetch-<remote>`
- Setting interval to "0" disables caching (always fetch)

## Test plan
- [ ] `wt config --global fetch_interval 1m` sets the interval
- [ ] `wt list` fetches and prints "Fetched from origin"
- [ ] Running `wt list` again within 1m prints "Skipping fetch (last fetch Xs ago)"
- [ ] `wt config fetch_interval 0` disables caching for current repo
- [ ] `wt config --show-origin` displays fetch_interval with source

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fetch_interval` configuration to control how often remote repositories are fetched (default: 5 minutes).
  * Remote fetches now skip if performed within the configured interval, reducing unnecessary operations.
  * Fetch intervals can be configured globally or customized per-repository.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->