### PR TITLE
Add fetch_interval config with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,6 @@ By default, worktrees are compared against the local default branch (e.g., `main
 # Compare against origin/main globally
 wt config --global remote origin
 
-# Auto-fetch before list/cleanup (only works when remote is set)
-wt config --global fetch true
-
 # Set minimum time between fetches (default: 5m)
 wt config --global fetch_interval 10m
 
@@ -311,6 +308,9 @@ wt config remote upstream
 
 # Disable fetch caching for current repo (always fetch)
 wt config fetch_interval 0
+
+# Disable fetch entirely for current repo
+wt config fetch_interval never
 
 # View current settings
 wt config --list
@@ -324,8 +324,7 @@ wt config --show-origin
 | Key | Default | Description |
 |-----|---------|-------------|
 | `remote` | `""` (empty) | Remote to compare against. Empty = local comparison |
-| `fetch` | `false` | Auto-fetch before list/cleanup (only applies when remote is set) |
-| `fetch_interval` | `5m` | Minimum time between fetches (e.g., `5m`, `1h`, `30s`). Set to `0` to always fetch |
+| `fetch_interval` | `5m` | Minimum time between fetches. Set to `0` to always fetch, or `never` to disable |
 
 ### Configuration File Structure
 
@@ -334,7 +333,6 @@ wt config --show-origin
 
 # Global settings
 remote: origin         # Compare to origin/branch
-fetch: true            # Fetch before comparing
 fetch_interval: 5m     # Minimum time between fetches
 
 # Per-repo overrides (keyed by repo path)
@@ -343,8 +341,7 @@ repos:
     remote: upstream       # This repo compares to upstream/branch
   /path/to/repo2:
     remote: ""             # This repo uses local comparison
-    fetch: false
-    fetch_interval: 0      # Always fetch for this repo
+    fetch_interval: never  # Never fetch for this repo
 ```
 
 ## Example Hooks

--- a/internal/commands/compare.go
+++ b/internal/commands/compare.go
@@ -58,9 +58,9 @@ func SetupCompare(cmd *cobra.Command) (*CompareSetup, error) {
 		// Remote comparison mode
 		remoteRef := remote + "/" + branch // e.g., "origin/main"
 
-		// Fetch first if enabled (only makes sense with a remote)
-		if userCfg.GetFetchForRepo(repoRoot) {
-			fetchInterval := userCfg.GetFetchIntervalForRepo(repoRoot)
+		// Fetch based on fetch_interval setting
+		fetchInterval := userCfg.GetFetchIntervalForRepo(repoRoot)
+		if fetchInterval != userconfig.FetchIntervalNever {
 			lastFetch, _ := git.GetLastFetchTime(repoRoot, remote)
 			timeSinceLastFetch := time.Since(lastFetch)
 

--- a/internal/commands/delete.go
+++ b/internal/commands/delete.go
@@ -146,8 +146,8 @@ func runDelete(cmd *cobra.Command, args []string) error {
 			// Remote comparison mode - fetch first if enabled
 			remoteRef := remote + "/" + comparisonBranch
 
-			if userCfg.GetFetchForRepo(repoRoot) {
-				fetchInterval := userCfg.GetFetchIntervalForRepo(repoRoot)
+			fetchInterval := userCfg.GetFetchIntervalForRepo(repoRoot)
+			if fetchInterval != userconfig.FetchIntervalNever {
 				lastFetch, _ := git.GetLastFetchTime(repoRoot, remote)
 				timeSinceLastFetch := time.Since(lastFetch)
 


### PR DESCRIPTION
## Summary
- Add `fetch_interval` config option to control fetch frequency when remote comparison is enabled
- Default to 5-minute caching between fetches to avoid hitting remote on every command
- Support `never` to disable fetching entirely, `0` to always fetch
- Remove separate `fetch` boolean - all fetch behavior controlled through `fetch_interval`

## Configuration
```bash
wt config --global fetch_interval 10m   # Fetch at most every 10 minutes
wt config --global fetch_interval 0     # Always fetch (no caching)
wt config fetch_interval never          # Disable fetch for current repo
```

## Test plan
- [ ] Verify `wt list` with remote shows "Skipping fetch" when within interval
- [ ] Verify `wt list` fetches after interval expires
- [ ] Verify `fetch_interval: never` disables fetching
- [ ] Verify `fetch_interval: 0` always fetches
- [ ] Verify invalid duration values are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced `fetch` configuration with `fetch_interval` for more granular control over data fetching intervals.

* **Documentation**
  * Updated configuration documentation to reflect new `fetch_interval` setting supporting duration values (e.g., "10m"), "0" for always fetch, and "never" to disable fetching.
  * Updated examples showing global and per-repo configuration overrides for the new setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->