### PR TITLE
Fix release script to handle special characters in notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,9 @@ run: build
 	./$(BUILD_DIR)/$(BINARY)
 
 # Create a release (bump version, tag, push)
-# Usage: make release patch "Fix bug"
-#        make release minor "Add feature"
-#        make release major "Breaking change"
+# Usage: NOTES="Fix bug" make release patch
+#        NOTES="Add feature" make release minor
+#        NOTES="Breaking change" make release major
 release:
 	@./scripts/release.sh $(filter-out $@,$(MAKECMDGOALS))
 
@@ -78,5 +78,5 @@ help:
 	@echo "  test        - Run tests"
 	@echo "  lint        - Run linters"
 	@echo "  tidy        - Run go mod tidy"
-	@echo "  release     - Create a release: make release <major|minor|patch> \"notes\""
+	@echo "  release     - Create a release: NOTES=\"notes\" make release <major|minor|patch>"
 	@echo "  help        - Show this help"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1 +1,1 @@
-Add fetch_interval configuration option to control fetch frequency and prevent repeated fetches. The fetch config option has been removed
+Add fetch_interval configuration option to control fetch frequency and prevent repeated fetches. The fetch config option has been removed; use fetch_interval: 0 for always or fetch_interval: never for never. Restructure documentation with dedicated usage and hooks guides.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,22 +17,24 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 VERSION_FILE="${REPO_ROOT}/VERSION"
 
 usage() {
-    echo "Usage: $0 <major|minor|patch> \"Release notes\""
+    echo "Usage: NOTES=\"Release notes\" $0 <major|minor|patch>"
     echo ""
     echo "Examples:"
-    echo "  $0 patch \"Fix bug in cleanup command\""
-    echo "  $0 minor \"Add new feature X\""
-    echo "  $0 major \"Breaking changes to config format\""
+    echo "  NOTES=\"Fix bug in cleanup command\" $0 patch"
+    echo "  NOTES=\"Add new feature X\" $0 minor"
+    echo "  NOTES=\"Breaking changes to config format\" $0 major"
+    echo ""
+    echo "Or via make:"
+    echo "  NOTES=\"Fix bug\" make release patch"
     exit 1
 }
 
-if [[ $# -lt 2 ]]; then
+if [[ $# -lt 1 ]]; then
     usage
 fi
 
 BUMP_TYPE="$1"
-shift
-RELEASE_NOTES="$*"
+RELEASE_NOTES="${NOTES:-}"
 
 if [[ ! "$BUMP_TYPE" =~ ^(major|minor|patch)$ ]]; then
     echo "Error: First argument must be 'major', 'minor', or 'patch'"


### PR DESCRIPTION
## Summary
- Use `NOTES` environment variable instead of positional arguments to avoid Make's argument parsing issues with semicolons and quotes
- Updates RELEASE_NOTES.md with complete v0.4.0 notes

## Test plan
- [ ] Run `NOTES="Test note; with semicolon" make release` (dry run) to verify parsing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)