### PR TITLE
Add server running status to vite-port-demo info hook

### DIFF
--- a/examples/vite-port-demo/scripts/show-info.sh
+++ b/examples/vite-port-demo/scripts/show-info.sh
@@ -9,5 +9,24 @@ if [ -z "$WT_INDEX" ]; then
     exit 0
 fi
 
+# ANSI codes for bold
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Check if a port is listening
+is_port_running() {
+    lsof -i ":$1" >/dev/null 2>&1
+}
+
+# Format status with optional bold
+format_status() {
+    local port=$1
+    if is_port_running "$port"; then
+        echo -e "(${BOLD}running${RESET})"
+    else
+        echo "(stopped)"
+    fi
+}
+
 PORT=$((5173 + WT_INDEX * 10))
-echo "URL: http://localhost:$PORT"
+echo -e "URL: http://localhost:$PORT $(format_status "$PORT")"


### PR DESCRIPTION
## Summary
- Show whether the dev server is running or stopped next to the URL in the info hook
- Uses `lsof` to check if the port is listening
- Displays status as "(running)" in bold or "(stopped)"

## Test plan
- [ ] Run `wt info` on a worktree with the vite server running - should show "(running)" in bold
- [ ] Run `wt info` on a worktree with the vite server stopped - should show "(stopped)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Port status indicator now displays alongside URLs, showing whether each port is running or stopped.
  * Enhanced text formatting with bold styling for improved readability of status information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->