### PR TITLE
Fix user config parsing error handling and support explicit empty remote

### DIFF
--- a/internal/commands/compare.go
+++ b/internal/commands/compare.go
@@ -38,7 +38,10 @@ func SetupCompare(cmd *cobra.Command) (*CompareSetup, error) {
 	}
 
 	// Load user configuration
-	userCfg, _ := userconfig.Load()
+	userCfg, err := userconfig.Load()
+	if err != nil {
+		cmd.PrintErrf("Warning: %v (using defaults)\n", err)
+	}
 
 	// Determine remote for this repo (empty = local comparison)
 	remote := userCfg.GetRemoteForRepo(repoRoot)

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -103,8 +103,12 @@ func printConfigList(cmd *cobra.Command, cfg *userconfig.UserConfig) error {
 
 	// Print per-repo values
 	for repoPath, repoConfig := range cfg.Repos {
-		if repoConfig.Remote != "" {
-			_, _ = fmt.Fprintf(out, "repos.%s.remote = %s\n", repoPath, repoConfig.Remote)
+		if repoConfig.Remote != nil {
+			remoteVal := *repoConfig.Remote
+			if remoteVal == "" {
+				remoteVal = "\"\"" // Display empty explicitly
+			}
+			_, _ = fmt.Fprintf(out, "repos.%s.remote = %s\n", repoPath, remoteVal)
 		}
 		if repoConfig.FetchInterval != nil {
 			_, _ = fmt.Fprintf(out, "repos.%s.fetch_interval = %s\n", repoPath, *repoConfig.FetchInterval)
@@ -131,8 +135,12 @@ func printConfigShowOrigin(cmd *cobra.Command, cfg *userconfig.UserConfig) error
 		fetchInterval := cfg.GetFetchIntervalForRepo(repoRoot)
 
 		// Determine source of remote
-		if repoConfig, ok := cfg.Repos[repoRoot]; ok && repoConfig.Remote != "" {
-			_, _ = fmt.Fprintf(out, "remote = %-20s %s (repos.%s)\n", remote, configPath, repoRoot)
+		if repoConfig, ok := cfg.Repos[repoRoot]; ok && repoConfig.Remote != nil {
+			remoteDisplay := remote
+			if remoteDisplay == "" {
+				remoteDisplay = "\"\""
+			}
+			_, _ = fmt.Fprintf(out, "remote = %-20s %s (repos.%s)\n", remoteDisplay, configPath, repoRoot)
 		} else if cfg.Remote != "" {
 			_, _ = fmt.Fprintf(out, "remote = %-20s %s (global)\n", remote, configPath)
 		} else {

--- a/internal/commands/delete.go
+++ b/internal/commands/delete.go
@@ -126,7 +126,10 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 		// Check for unmerged commits (commits ahead of comparison ref)
 		// Load user configuration for fetch/remote settings
-		userCfg, _ := userconfig.Load()
+		userCfg, err := userconfig.Load()
+		if err != nil {
+			cmd.PrintErrf("Warning: %v (using defaults)\n", err)
+		}
 
 		// Determine remote for this repo (empty = local comparison)
 		remote := userCfg.GetRemoteForRepo(repoRoot)


### PR DESCRIPTION
## Summary
- Show warning when user config fails to parse instead of silently using defaults
- Change `RepoConfig.Remote` to pointer type to distinguish "unset" (nil → falls back to global) from "explicit empty" (pointer to "" → forces local comparison)
- Allow `wt config remote ""` to set a per-repo override that disables remote comparison
- Display explicit empty values as `""` in `--list` and `--show-origin` output

## Test plan
- [x] Run `make test` - all tests pass
- [x] Break config with invalid YAML, run `wt list` - should show warning and continue
- [x] Run `wt config remote ""` then `wt config --show-origin` - should show `remote = ""`
- [x] Run `wt list` - should compare to local `main` instead of `origin/main`
- [x] Run `wt config --unset remote` - should fall back to global

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during configuration loading with warning notifications
  * Enhanced remote configuration management to better distinguish between unset and empty values

* **Tests**
  * Updated test cases to reflect configuration handling improvements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->