### PR TITLE
Fix release slash command to use NOTES env var

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -20,7 +20,7 @@ Prepare and execute a release for the wt project.
    - Proposed release notes (concise, 1-3 sentences)
    - Recommended bump type with reasoning
 6. Ask the user to approve or modify the release notes and bump type
-7. Upon approval, run: `make release <bump-type> "<release-notes>"`
+7. Upon approval, run: `NOTES="<release-notes>" make release <bump-type>`
 
 ## Important
 


### PR DESCRIPTION
## Summary
- Fix the `/release` slash command to use the correct invocation format for the release script
- The script expects `NOTES="..." make release <type>`, not `make release <type> "..."`

## Test plan
- [ ] Run `/release` command and verify it executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release notes invocation method to use environment variable configuration instead of inline argument passing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->