### PR TITLE
Add worktree name completions for delete and info commands

### DIFF
--- a/internal/commands/completion_test.go
+++ b/internal/commands/completion_test.go
@@ -419,7 +419,7 @@ func TestCompletionSubcommands(t *testing.T) {
 	// Test that all expected subcommands are registered on the root command
 	expectedCommands := []string{
 		"cd", "cleanup", "completion", "create", "delete",
-		"exit", "init", "list", "root", "version",
+		"exit", "info", "init", "list", "root", "version",
 	}
 
 	registeredCommands := make(map[string]bool)

--- a/scripts/completions/wt.bash
+++ b/scripts/completions/wt.bash
@@ -441,6 +441,34 @@ _wt_completion()
     noun_aliases=()
 }
 
+_wt_config()
+{
+    last_command="wt_config"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--global")
+    local_nonpersistent_flags+=("--global")
+    flags+=("--list")
+    local_nonpersistent_flags+=("--list")
+    flags+=("--show-origin")
+    local_nonpersistent_flags+=("--show-origin")
+    flags+=("--unset")
+    local_nonpersistent_flags+=("--unset")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _wt_create()
 {
     last_command="wt_create"
@@ -523,6 +551,27 @@ _wt_exit()
 _wt_help()
 {
     last_command="wt_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_wt_info()
+{
+    last_command="wt_info"
 
     command_aliases=()
 
@@ -638,10 +687,12 @@ _wt_root_command()
     commands+=("cd")
     commands+=("cleanup")
     commands+=("completion")
+    commands+=("config")
     commands+=("create")
     commands+=("delete")
     commands+=("exit")
     commands+=("help")
+    commands+=("info")
     commands+=("init")
     commands+=("list")
     if [[ -z "${BASH_VERSION:-}" || "${BASH_VERSINFO[0]:-}" -gt 3 ]]; then


### PR DESCRIPTION
## Summary
- Fixed zsh shell completion for `wt delete`: the nested `_arguments` call conflicted with the outer state machine, preventing worktree names from appearing on tab. Now uses the same direct listing approach as `wt cd`
- Added `info` command to shell completion scripts (zsh, bash, fish) so `wt info <TAB>` suggests worktree names
- Updated pre-generated completion scripts and subcommand test

## Test plan
- [x] `make build` succeeds
- [x] `make test` — all tests pass
- [x] `wt delete <TAB>` shows available worktree names (zsh)
- [x] `wt info <TAB>` shows available worktree names (zsh/bash/fish)
- [x] `wt cd <TAB>` still works as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "info" subcommand to show detailed worktree information.
  * Added "config" subcommand for configuration management.
  * Added "--branch" flag to the create command.
  * Improved shell completions for bash, zsh, and fish: exposes new subcommands and provides smarter name/flag completion for cd, delete, and info.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->