### PR TITLE
Add clickable PR links in list and cleanup output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,6 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/term v0.41.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.41.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -11,5 +12,4 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,10 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
+golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -130,6 +130,9 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Resolve remote URL for PR hyperlinks
+	repoURL := git.GetRemoteURL(setup.RepoRoot, "origin")
+
 	// Display candidates
 	out := cmd.OutOrStdout()
 	_, _ = fmt.Fprintln(out, "Worktrees eligible for cleanup:")
@@ -150,7 +153,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	// Print header and rows with dynamic widths
 	_, _ = fmt.Fprintf(out, "  %-*s  %-*s  %s\n", nameWidth, "NAME", branchWidth, "BRANCH", "STATUS")
 	for _, c := range candidates {
-		statusStr := FormatCompactStatus(c.status, "")
+		statusStr := FormatCompactStatus(c.status, repoURL)
 		_, _ = fmt.Fprintf(out, "  %-*s  %-*s  %s\n", nameWidth, c.name, branchWidth, c.branch, statusStr)
 	}
 	_, _ = fmt.Fprintln(out)

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -131,7 +131,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve link context for PR hyperlinks (checks remote URL + TTY)
-	links := NewLinkContext(setup.RepoRoot)
+	links := NewLinkContext(setup.RepoRoot, cmd.OutOrStdout())
 
 	// Display candidates
 	out := cmd.OutOrStdout()

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -130,8 +130,8 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Resolve remote URL for PR hyperlinks
-	repoURL := git.GetRemoteURL(setup.RepoRoot, "origin")
+	// Resolve link context for PR hyperlinks (checks remote URL + TTY)
+	links := NewLinkContext(setup.RepoRoot)
 
 	// Display candidates
 	out := cmd.OutOrStdout()
@@ -153,7 +153,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	// Print header and rows with dynamic widths
 	_, _ = fmt.Fprintf(out, "  %-*s  %-*s  %s\n", nameWidth, "NAME", branchWidth, "BRANCH", "STATUS")
 	for _, c := range candidates {
-		statusStr := FormatCompactStatus(c.status, repoURL)
+		statusStr := FormatCompactStatus(c.status, links)
 		_, _ = fmt.Fprintf(out, "  %-*s  %-*s  %s\n", nameWidth, c.name, branchWidth, c.branch, statusStr)
 	}
 	_, _ = fmt.Fprintln(out)

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -150,7 +150,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	// Print header and rows with dynamic widths
 	_, _ = fmt.Fprintf(out, "  %-*s  %-*s  %s\n", nameWidth, "NAME", branchWidth, "BRANCH", "STATUS")
 	for _, c := range candidates {
-		statusStr := FormatCompactStatus(c.status)
+		statusStr := FormatCompactStatus(c.status, "")
 		_, _ = fmt.Fprintf(out, "  %-*s  %-*s  %s\n", nameWidth, c.name, branchWidth, c.branch, statusStr)
 	}
 	_, _ = fmt.Fprintln(out)

--- a/internal/commands/format.go
+++ b/internal/commands/format.go
@@ -24,6 +24,7 @@ type VerboseInfo struct {
 	Status        *git.WorktreeStatus
 	CurrentMarker string
 	HookOutput    string
+	RepoURL       string // GitHub base URL for PR hyperlinks (empty disables linking)
 }
 
 // PrintVerboseWorktree prints a single worktree in verbose format
@@ -78,7 +79,7 @@ func collectBuiltinPairs(info VerboseInfo) []KeyValue {
 		})
 	}
 
-	statusStr := FormatCompactStatus(info.Status)
+	statusStr := FormatCompactStatus(info.Status, info.RepoURL)
 	if statusStr != "" {
 		pairs = append(pairs, KeyValue{Key: "Status", Value: statusStr})
 	}

--- a/internal/commands/format.go
+++ b/internal/commands/format.go
@@ -24,7 +24,7 @@ type VerboseInfo struct {
 	Status        *git.WorktreeStatus
 	CurrentMarker string
 	HookOutput    string
-	RepoURL       string // GitHub base URL for PR hyperlinks (empty disables linking)
+	Links         LinkContext
 }
 
 // PrintVerboseWorktree prints a single worktree in verbose format
@@ -79,7 +79,7 @@ func collectBuiltinPairs(info VerboseInfo) []KeyValue {
 		})
 	}
 
-	statusStr := FormatCompactStatus(info.Status, info.RepoURL)
+	statusStr := FormatCompactStatus(info.Status, info.Links)
 	if statusStr != "" {
 		pairs = append(pairs, KeyValue{Key: "Status", Value: statusStr})
 	}

--- a/internal/commands/info.go
+++ b/internal/commands/info.go
@@ -108,6 +108,9 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		hookOutput, _ = hooks.RunInfo(setup.Config, env)
 	}
 
+	// Resolve link context for PR hyperlinks (checks remote URL + TTY)
+	links := NewLinkContext(setup.RepoRoot)
+
 	// Print output
 	out := cmd.OutOrStdout()
 	separator := strings.Repeat("=", 80)
@@ -121,6 +124,7 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		Status:        status,
 		CurrentMarker: currentMarker,
 		HookOutput:    hookOutput,
+		Links:         links,
 	})
 	_, _ = fmt.Fprintln(out, separator)
 

--- a/internal/commands/info.go
+++ b/internal/commands/info.go
@@ -109,7 +109,7 @@ func runInfo(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve link context for PR hyperlinks (checks remote URL + TTY)
-	links := NewLinkContext(setup.RepoRoot)
+	links := NewLinkContext(setup.RepoRoot, cmd.OutOrStdout())
 
 	// Print output
 	out := cmd.OutOrStdout()

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -114,11 +114,14 @@ func runList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Resolve remote URL for PR hyperlinks
+	repoURL := git.GetRemoteURL(setup.RepoRoot, "origin")
+
 	// Print based on verbose flag
 	if verboseFlag {
-		printVerboseWorktrees(cmd, managedWorktrees, setup.Config, setup.RepoRoot)
+		printVerboseWorktrees(cmd, managedWorktrees, setup.Config, setup.RepoRoot, repoURL)
 	} else {
-		printCompactWorktrees(cmd, managedWorktrees)
+		printCompactWorktrees(cmd, managedWorktrees, repoURL)
 	}
 
 	return nil
@@ -126,7 +129,7 @@ func runList(cmd *cobra.Command, args []string) error {
 
 
 // printCompactWorktrees prints worktrees in compact table format
-func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo) {
+func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, repoURL string) {
 	out := cmd.OutOrStdout()
 
 	// Calculate column widths based on content
@@ -144,7 +147,7 @@ func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo) {
 	// Print header and rows with dynamic widths
 	_, _ = fmt.Fprintf(out, "  %-*s  %5s  %-*s  %s\n", nameWidth, "NAME", "INDEX", branchWidth, "BRANCH", "STATUS")
 	for _, wt := range worktrees {
-		statusStr := FormatCompactStatus(wt.status)
+		statusStr := FormatCompactStatus(wt.status, repoURL)
 		indexStr := "-"
 		if wt.index > 0 {
 			indexStr = fmt.Sprintf("%d", wt.index)
@@ -154,7 +157,7 @@ func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo) {
 }
 
 // printVerboseWorktrees prints worktrees in detailed multi-line format
-func printVerboseWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, cfg *config.Config, repoRoot string) {
+func printVerboseWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, cfg *config.Config, repoRoot string, repoURL string) {
 	out := cmd.OutOrStdout()
 	separator := strings.Repeat("=", 80)
 
@@ -182,6 +185,7 @@ func printVerboseWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, cfg *co
 			Index:         wt.index,
 			CurrentMarker: wt.currentMarker,
 			HookOutput:    hookOutput,
+			RepoURL:       repoURL,
 		}
 		if wt.status != nil {
 			info.CreatedAt = wt.status.CreatedAt

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -114,14 +114,14 @@ func runList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Resolve remote URL for PR hyperlinks
-	repoURL := git.GetRemoteURL(setup.RepoRoot, "origin")
+	// Resolve link context for PR hyperlinks (checks remote URL + TTY)
+	links := NewLinkContext(setup.RepoRoot)
 
 	// Print based on verbose flag
 	if verboseFlag {
-		printVerboseWorktrees(cmd, managedWorktrees, setup.Config, setup.RepoRoot, repoURL)
+		printVerboseWorktrees(cmd, managedWorktrees, setup.Config, setup.RepoRoot, links)
 	} else {
-		printCompactWorktrees(cmd, managedWorktrees, repoURL)
+		printCompactWorktrees(cmd, managedWorktrees, links)
 	}
 
 	return nil
@@ -129,7 +129,7 @@ func runList(cmd *cobra.Command, args []string) error {
 
 
 // printCompactWorktrees prints worktrees in compact table format
-func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, repoURL string) {
+func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, links LinkContext) {
 	out := cmd.OutOrStdout()
 
 	// Calculate column widths based on content
@@ -147,7 +147,7 @@ func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, repoURL
 	// Print header and rows with dynamic widths
 	_, _ = fmt.Fprintf(out, "  %-*s  %5s  %-*s  %s\n", nameWidth, "NAME", "INDEX", branchWidth, "BRANCH", "STATUS")
 	for _, wt := range worktrees {
-		statusStr := FormatCompactStatus(wt.status, repoURL)
+		statusStr := FormatCompactStatus(wt.status, links)
 		indexStr := "-"
 		if wt.index > 0 {
 			indexStr = fmt.Sprintf("%d", wt.index)
@@ -157,7 +157,7 @@ func printCompactWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, repoURL
 }
 
 // printVerboseWorktrees prints worktrees in detailed multi-line format
-func printVerboseWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, cfg *config.Config, repoRoot string, repoURL string) {
+func printVerboseWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, cfg *config.Config, repoRoot string, links LinkContext) {
 	out := cmd.OutOrStdout()
 	separator := strings.Repeat("=", 80)
 
@@ -185,7 +185,7 @@ func printVerboseWorktrees(cmd *cobra.Command, worktrees []worktreeInfo, cfg *co
 			Index:         wt.index,
 			CurrentMarker: wt.currentMarker,
 			HookOutput:    hookOutput,
-			RepoURL:       repoURL,
+			Links:         links,
 		}
 		if wt.status != nil {
 			info.CreatedAt = wt.status.CreatedAt

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -115,7 +115,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve link context for PR hyperlinks (checks remote URL + TTY)
-	links := NewLinkContext(setup.RepoRoot)
+	links := NewLinkContext(setup.RepoRoot, cmd.OutOrStdout())
 
 	// Print based on verbose flag
 	if verboseFlag {

--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -114,7 +114,7 @@ func TestFormatCompactStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatCompactStatus(tt.status, "")
+			got := FormatCompactStatus(tt.status, LinkContext{})
 
 			// Strip ANSI codes for content comparison
 			stripped := stripANSI(got)
@@ -171,7 +171,7 @@ func TestFormatCompactStatusInProgressRequiresUnmerged(t *testing.T) {
 				CommitsAhead: tt.commitsAhead,
 				IsMerged:     tt.isMerged,
 			}
-			got := stripANSI(FormatCompactStatus(status, ""))
+			got := stripANSI(FormatCompactStatus(status, LinkContext{}))
 
 			if tt.wantStatus == "" {
 				if strings.Contains(got, "[") {
@@ -219,7 +219,7 @@ func TestDirtyIsAdditive(t *testing.T) {
 
 	for _, tt := range states {
 		t.Run(tt.name+" with dirty", func(t *testing.T) {
-			got := stripANSI(FormatCompactStatus(tt.status, ""))
+			got := stripANSI(FormatCompactStatus(tt.status, LinkContext{}))
 
 			// Should contain both the state and dirty
 			if !strings.Contains(got, tt.name) {
@@ -238,10 +238,10 @@ func TestDirtyIsAdditive(t *testing.T) {
 
 func TestFormatMergedStatus(t *testing.T) {
 	tests := []struct {
-		name    string
-		prs     []string
-		repoURL string
-		want    string
+		name  string
+		prs   []string
+		links LinkContext
+		want  string
 	}{
 		{
 			name: "no PRs",
@@ -249,32 +249,44 @@ func TestFormatMergedStatus(t *testing.T) {
 			want: "merged",
 		},
 		{
-			name: "single PR without repo URL",
+			name: "single PR without links",
 			prs:  []string{"#42"},
 			want: "merged in #42",
 		},
 		{
-			name: "multiple PRs without repo URL",
+			name: "multiple PRs without links",
 			prs:  []string{"#1", "#2"},
 			want: "merged in #1, #2",
 		},
 		{
-			name:    "single PR with repo URL",
-			prs:     []string{"#42"},
-			repoURL: "https://github.com/owner/repo",
-			want:    "merged in \033]8;;https://github.com/owner/repo/pull/42\033\\#42\033]8;;\033\\",
+			name:  "single PR with links enabled",
+			prs:   []string{"#42"},
+			links: LinkContext{RepoURL: "https://github.com/owner/repo", IsTTY: true},
+			want:  "merged in \033]8;;https://github.com/owner/repo/pull/42\033\\#42\033]8;;\033\\",
 		},
 		{
-			name:    "multiple PRs with repo URL",
-			prs:     []string{"#1", "#2"},
-			repoURL: "https://github.com/owner/repo",
-			want:    "merged in \033]8;;https://github.com/owner/repo/pull/1\033\\#1\033]8;;\033\\, \033]8;;https://github.com/owner/repo/pull/2\033\\#2\033]8;;\033\\",
+			name:  "multiple PRs with links enabled",
+			prs:   []string{"#1", "#2"},
+			links: LinkContext{RepoURL: "https://github.com/owner/repo", IsTTY: true},
+			want:  "merged in \033]8;;https://github.com/owner/repo/pull/1\033\\#1\033]8;;\033\\, \033]8;;https://github.com/owner/repo/pull/2\033\\#2\033]8;;\033\\",
+		},
+		{
+			name:  "repo URL but not a TTY - no links",
+			prs:   []string{"#42"},
+			links: LinkContext{RepoURL: "https://github.com/owner/repo", IsTTY: false},
+			want:  "merged in #42",
+		},
+		{
+			name:  "TTY but no repo URL - no links",
+			prs:   []string{"#42"},
+			links: LinkContext{RepoURL: "", IsTTY: true},
+			want:  "merged in #42",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatMergedStatus(tt.prs, tt.repoURL)
+			got := FormatMergedStatus(tt.prs, tt.links)
 			if got != tt.want {
 				t.Errorf("FormatMergedStatus() = %q, want %q", got, tt.want)
 			}
@@ -282,18 +294,37 @@ func TestFormatMergedStatus(t *testing.T) {
 	}
 }
 
-func TestFormatCompactStatusWithRepoURL(t *testing.T) {
+func TestFormatCompactStatusWithLinks(t *testing.T) {
 	status := &git.WorktreeStatus{
 		IsMerged:  true,
 		MergedPRs: []string{"#99"},
 	}
-	got := FormatCompactStatus(status, "https://github.com/owner/repo")
+	links := LinkContext{RepoURL: "https://github.com/owner/repo", IsTTY: true}
+	got := FormatCompactStatus(status, links)
 
 	// Should contain OSC 8 hyperlink
 	if !strings.Contains(got, "\033]8;;https://github.com/owner/repo/pull/99\033\\") {
 		t.Errorf("expected OSC 8 link in output, got %q", got)
 	}
 	// Should still contain the visible text
+	if !strings.Contains(got, "#99") {
+		t.Errorf("expected #99 in output, got %q", got)
+	}
+}
+
+func TestFormatCompactStatusNoLinksWhenNotTTY(t *testing.T) {
+	status := &git.WorktreeStatus{
+		IsMerged:  true,
+		MergedPRs: []string{"#99"},
+	}
+	links := LinkContext{RepoURL: "https://github.com/owner/repo", IsTTY: false}
+	got := FormatCompactStatus(status, links)
+
+	// Should NOT contain OSC 8 sequences
+	if strings.Contains(got, "\033]8;;") {
+		t.Errorf("expected no OSC 8 link when not a TTY, got %q", got)
+	}
+	// Should contain plain text
 	if !strings.Contains(got, "#99") {
 		t.Errorf("expected #99 in output, got %q", got)
 	}

--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -114,7 +114,7 @@ func TestFormatCompactStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatCompactStatus(tt.status)
+			got := FormatCompactStatus(tt.status, "")
 
 			// Strip ANSI codes for content comparison
 			stripped := stripANSI(got)
@@ -171,7 +171,7 @@ func TestFormatCompactStatusInProgressRequiresUnmerged(t *testing.T) {
 				CommitsAhead: tt.commitsAhead,
 				IsMerged:     tt.isMerged,
 			}
-			got := stripANSI(FormatCompactStatus(status))
+			got := stripANSI(FormatCompactStatus(status, ""))
 
 			if tt.wantStatus == "" {
 				if strings.Contains(got, "[") {
@@ -219,7 +219,7 @@ func TestDirtyIsAdditive(t *testing.T) {
 
 	for _, tt := range states {
 		t.Run(tt.name+" with dirty", func(t *testing.T) {
-			got := stripANSI(FormatCompactStatus(tt.status))
+			got := stripANSI(FormatCompactStatus(tt.status, ""))
 
 			// Should contain both the state and dirty
 			if !strings.Contains(got, tt.name) {
@@ -233,6 +233,69 @@ func TestDirtyIsAdditive(t *testing.T) {
 				t.Errorf("expected comma-separated statuses, got %q", got)
 			}
 		})
+	}
+}
+
+func TestFormatMergedStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		prs     []string
+		repoURL string
+		want    string
+	}{
+		{
+			name: "no PRs",
+			prs:  nil,
+			want: "merged",
+		},
+		{
+			name: "single PR without repo URL",
+			prs:  []string{"#42"},
+			want: "merged in #42",
+		},
+		{
+			name: "multiple PRs without repo URL",
+			prs:  []string{"#1", "#2"},
+			want: "merged in #1, #2",
+		},
+		{
+			name:    "single PR with repo URL",
+			prs:     []string{"#42"},
+			repoURL: "https://github.com/owner/repo",
+			want:    "merged in \033]8;;https://github.com/owner/repo/pull/42\033\\#42\033]8;;\033\\",
+		},
+		{
+			name:    "multiple PRs with repo URL",
+			prs:     []string{"#1", "#2"},
+			repoURL: "https://github.com/owner/repo",
+			want:    "merged in \033]8;;https://github.com/owner/repo/pull/1\033\\#1\033]8;;\033\\, \033]8;;https://github.com/owner/repo/pull/2\033\\#2\033]8;;\033\\",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatMergedStatus(tt.prs, tt.repoURL)
+			if got != tt.want {
+				t.Errorf("FormatMergedStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatCompactStatusWithRepoURL(t *testing.T) {
+	status := &git.WorktreeStatus{
+		IsMerged:  true,
+		MergedPRs: []string{"#99"},
+	}
+	got := FormatCompactStatus(status, "https://github.com/owner/repo")
+
+	// Should contain OSC 8 hyperlink
+	if !strings.Contains(got, "\033]8;;https://github.com/owner/repo/pull/99\033\\") {
+		t.Errorf("expected OSC 8 link in output, got %q", got)
+	}
+	// Should still contain the visible text
+	if !strings.Contains(got, "#99") {
+		t.Errorf("expected #99 in output, got %q", got)
 	}
 }
 

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -16,7 +16,8 @@ const (
 // FormatCompactStatus builds the compact status string with arrows.
 // State indicators (mutually exclusive): new, in_progress, merged
 // dirty is additive and can appear alongside any state.
-func FormatCompactStatus(status *git.WorktreeStatus) string {
+// repoURL is the GitHub base URL (e.g. "https://github.com/owner/repo") for PR links; empty disables linking.
+func FormatCompactStatus(status *git.WorktreeStatus, repoURL string) string {
 	if status == nil {
 		return ""
 	}
@@ -40,7 +41,7 @@ func FormatCompactStatus(status *git.WorktreeStatus) string {
 		// in_progress: has commits ahead that aren't merged
 		statusTags = append(statusTags, bold+"in_progress"+reset)
 	} else if status.IsMerged && status.CommitsAhead == 0 {
-		statusTags = append(statusTags, FormatMergedStatus(status.MergedPRs))
+		statusTags = append(statusTags, FormatMergedStatus(status.MergedPRs, repoURL))
 	}
 
 	// dirty is additive - can appear with any state
@@ -57,9 +58,20 @@ func FormatCompactStatus(status *git.WorktreeStatus) string {
 
 // FormatMergedStatus returns the merged status string.
 // If PR numbers are found, returns "merged in #1, #2", otherwise just "merged".
-func FormatMergedStatus(prs []string) string {
+// When repoURL is non-empty, PR numbers are wrapped in OSC 8 terminal hyperlinks.
+func FormatMergedStatus(prs []string, repoURL string) string {
 	if len(prs) == 0 {
 		return "merged"
+	}
+	if repoURL != "" {
+		linked := make([]string, len(prs))
+		for i, pr := range prs {
+			// pr is like "#123", extract the number
+			num := strings.TrimPrefix(pr, "#")
+			url := repoURL + "/pull/" + num
+			linked[i] = fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", url, pr)
+		}
+		return "merged in " + strings.Join(linked, ", ")
 	}
 	return "merged in " + strings.Join(prs, ", ")
 }

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/agarcher/wt/internal/git"
+	"golang.org/x/term"
 )
 
 // ANSI codes for bold text
@@ -13,11 +15,32 @@ const (
 	reset = "\033[0m"
 )
 
+// LinkContext controls whether PR numbers are rendered as clickable OSC 8 hyperlinks.
+// Use NewLinkContext to construct; the zero value disables linking.
+type LinkContext struct {
+	RepoURL string // GitHub base URL (e.g. "https://github.com/owner/repo")
+	IsTTY   bool   // whether stdout is a terminal
+}
+
+// NewLinkContext creates a LinkContext by resolving the remote URL and checking
+// whether stdout is a terminal. This is the standard way to construct a LinkContext
+// so that callers don't forget either check.
+func NewLinkContext(repoRoot string) LinkContext {
+	return LinkContext{
+		RepoURL: git.GetRemoteURL(repoRoot, "origin"),
+		IsTTY:   term.IsTerminal(int(os.Stdout.Fd())),
+	}
+}
+
+// linksEnabled returns true when both a repo URL is available and output is a TTY.
+func (lc LinkContext) linksEnabled() bool {
+	return lc.RepoURL != "" && lc.IsTTY
+}
+
 // FormatCompactStatus builds the compact status string with arrows.
 // State indicators (mutually exclusive): new, in_progress, merged
 // dirty is additive and can appear alongside any state.
-// repoURL is the GitHub base URL (e.g. "https://github.com/owner/repo") for PR links; empty disables linking.
-func FormatCompactStatus(status *git.WorktreeStatus, repoURL string) string {
+func FormatCompactStatus(status *git.WorktreeStatus, links LinkContext) string {
 	if status == nil {
 		return ""
 	}
@@ -41,7 +64,7 @@ func FormatCompactStatus(status *git.WorktreeStatus, repoURL string) string {
 		// in_progress: has commits ahead that aren't merged
 		statusTags = append(statusTags, bold+"in_progress"+reset)
 	} else if status.IsMerged && status.CommitsAhead == 0 {
-		statusTags = append(statusTags, FormatMergedStatus(status.MergedPRs, repoURL))
+		statusTags = append(statusTags, FormatMergedStatus(status.MergedPRs, links))
 	}
 
 	// dirty is additive - can appear with any state
@@ -58,17 +81,17 @@ func FormatCompactStatus(status *git.WorktreeStatus, repoURL string) string {
 
 // FormatMergedStatus returns the merged status string.
 // If PR numbers are found, returns "merged in #1, #2", otherwise just "merged".
-// When repoURL is non-empty, PR numbers are wrapped in OSC 8 terminal hyperlinks.
-func FormatMergedStatus(prs []string, repoURL string) string {
+// When links are enabled, PR numbers are wrapped in OSC 8 terminal hyperlinks.
+func FormatMergedStatus(prs []string, links LinkContext) string {
 	if len(prs) == 0 {
 		return "merged"
 	}
-	if repoURL != "" {
+	if links.linksEnabled() {
 		linked := make([]string, len(prs))
 		for i, pr := range prs {
 			// pr is like "#123", extract the number
 			num := strings.TrimPrefix(pr, "#")
-			url := repoURL + "/pull/" + num
+			url := links.RepoURL + "/pull/" + num
 			linked[i] = fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", url, pr)
 		}
 		return "merged in " + strings.Join(linked, ", ")

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -23,13 +24,14 @@ type LinkContext struct {
 }
 
 // NewLinkContext creates a LinkContext by resolving the remote URL and checking
-// whether stdout is a terminal. This is the standard way to construct a LinkContext
-// so that callers don't forget either check.
-func NewLinkContext(repoRoot string) LinkContext {
-	return LinkContext{
-		RepoURL: git.GetRemoteURL(repoRoot, "origin"),
-		IsTTY:   term.IsTerminal(int(os.Stdout.Fd())),
+// whether the output writer is a terminal. Pass cmd.OutOrStdout() so the check
+// reflects the actual output sink (not necessarily os.Stdout).
+func NewLinkContext(repoRoot string, out io.Writer) LinkContext {
+	lc := LinkContext{RepoURL: git.GetRemoteURL(repoRoot, "origin")}
+	if f, ok := out.(*os.File); ok {
+		lc.IsTTY = term.IsTerminal(int(f.Fd()))
 	}
+	return lc
 }
 
 // linksEnabled returns true when both a repo URL is available and output is a TTY.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -13,8 +13,10 @@ import (
 	"time"
 )
 
-// sshURLRegex matches SSH-style git URLs like git@github.com:owner/repo.git
-var sshURLRegex = regexp.MustCompile(`^git@github\.com:(.+?)(?:\.git)?$`)
+// sshURLRegex matches SSH-style git URLs:
+//   - scp-style: git@github.com:owner/repo.git
+//   - URI-style: ssh://git@github.com/owner/repo.git
+var sshURLRegex = regexp.MustCompile(`^(?:git@github\.com:|ssh://git@github\.com/)(.+?)(?:\.git)?$`)
 
 // httpsURLRegex matches HTTPS GitHub URLs like https://github.com/owner/repo.git
 var httpsURLRegex = regexp.MustCompile(`^https://github\.com/(.+?)(?:\.git)?$`)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -13,6 +13,36 @@ import (
 	"time"
 )
 
+// sshURLRegex matches SSH-style git URLs like git@github.com:owner/repo.git
+var sshURLRegex = regexp.MustCompile(`^git@github\.com:(.+?)(?:\.git)?$`)
+
+// httpsURLRegex matches HTTPS GitHub URLs like https://github.com/owner/repo.git
+var httpsURLRegex = regexp.MustCompile(`^https://github\.com/(.+?)(?:\.git)?$`)
+
+// GetRemoteURL returns the GitHub HTTPS base URL for the given remote (e.g. "https://github.com/owner/repo").
+// Returns empty string if the remote is not a GitHub URL or on error.
+func GetRemoteURL(repoRoot, remote string) string {
+	cmd := exec.Command("git", "remote", "get-url", remote)
+	cmd.Dir = repoRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return ParseGitHubURL(strings.TrimSpace(string(output)))
+}
+
+// ParseGitHubURL converts a git remote URL (SSH or HTTPS) to a GitHub HTTPS base URL.
+// Returns empty string if the URL is not a recognized GitHub URL.
+func ParseGitHubURL(rawURL string) string {
+	if m := sshURLRegex.FindStringSubmatch(rawURL); len(m) >= 2 {
+		return "https://github.com/" + m[1]
+	}
+	if m := httpsURLRegex.FindStringSubmatch(rawURL); len(m) >= 2 {
+		return "https://github.com/" + m[1]
+	}
+	return ""
+}
+
 // Worktree represents a git worktree
 type Worktree struct {
 	Path   string

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1116,6 +1116,64 @@ func TestRefExists(t *testing.T) {
 	}
 }
 
+func TestParseGitHubURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "SSH URL",
+			url:  "git@github.com:owner/repo.git",
+			want: "https://github.com/owner/repo",
+		},
+		{
+			name: "SSH URL without .git",
+			url:  "git@github.com:owner/repo",
+			want: "https://github.com/owner/repo",
+		},
+		{
+			name: "HTTPS URL",
+			url:  "https://github.com/owner/repo.git",
+			want: "https://github.com/owner/repo",
+		},
+		{
+			name: "HTTPS URL without .git",
+			url:  "https://github.com/owner/repo",
+			want: "https://github.com/owner/repo",
+		},
+		{
+			name: "non-GitHub SSH",
+			url:  "git@gitlab.com:owner/repo.git",
+			want: "",
+		},
+		{
+			name: "non-GitHub HTTPS",
+			url:  "https://gitlab.com/owner/repo.git",
+			want: "",
+		},
+		{
+			name: "empty string",
+			url:  "",
+			want: "",
+		},
+		{
+			name: "SSH URL with org/repo path",
+			url:  "git@github.com:my-org/my-repo.git",
+			want: "https://github.com/my-org/my-repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseGitHubURL(tt.url)
+			if got != tt.want {
+				t.Errorf("ParseGitHubURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFetchRemoteQuiet(t *testing.T) {
 	repoRoot, cleanup := setupTestRepo(t)
 	defer cleanup()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1162,6 +1162,21 @@ func TestParseGitHubURL(t *testing.T) {
 			url:  "git@github.com:my-org/my-repo.git",
 			want: "https://github.com/my-org/my-repo",
 		},
+		{
+			name: "SSH URI-style URL",
+			url:  "ssh://git@github.com/owner/repo.git",
+			want: "https://github.com/owner/repo",
+		},
+		{
+			name: "SSH URI-style URL without .git",
+			url:  "ssh://git@github.com/owner/repo",
+			want: "https://github.com/owner/repo",
+		},
+		{
+			name: "non-GitHub SSH URI-style",
+			url:  "ssh://git@gitlab.com/owner/repo.git",
+			want: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- PR numbers in merged status (e.g. `#123`) are now wrapped in [OSC 8 terminal hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda), making them clickable in supported terminals
- Adds `GetRemoteURL`/`ParseGitHubURL` to resolve the GitHub base URL from the `origin` remote (supports both SSH and HTTPS URLs)
- Threads `repoURL` through `wt list` (compact and verbose) and `wt cleanup` to `FormatMergedStatus`

## Test plan
- [x] `TestParseGitHubURL` — SSH, HTTPS, `.git` suffix, non-GitHub remotes
- [x] `TestFormatMergedStatus` — plain text and OSC 8 link output
- [x] `TestFormatCompactStatusWithRepoURL` — end-to-end through `FormatCompactStatus`
- [x] All existing tests pass with updated signatures
- [ ] Manual: run `wt list` in a repo with merged PRs and verify links are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR references in status, list, and info outputs can appear as clickable GitHub links when a repository URL is available and output is a TTY; repo URL is auto-detected from the local repository.

* **Tests**
  * Added tests for GitHub URL parsing and hyperlink formatting behavior (including TTY vs. non‑TTY cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->