### PR TITLE
Accept remote-tracking branches in BranchExists

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -126,11 +126,34 @@ func ListWorktrees(repoRoot string) ([]Worktree, error) {
 	return worktrees, scanner.Err()
 }
 
-// BranchExists checks if a branch exists
+// BranchExists checks if a branch exists locally or as a remote-tracking branch.
+// Remote-tracking matches mirror `git worktree add`'s DWIM behavior, which creates
+// a local tracking branch when the name resolves to a unique remote branch.
 func BranchExists(repoRoot, branchName string) bool {
 	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
 	cmd.Dir = repoRoot
-	return cmd.Run() == nil
+	if cmd.Run() == nil {
+		return true
+	}
+
+	cmd = exec.Command("git", "remote")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	for _, remote := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		remote = strings.TrimSpace(remote)
+		if remote == "" {
+			continue
+		}
+		cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/remotes/"+remote+"/"+branchName)
+		cmd.Dir = repoRoot
+		if cmd.Run() == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // GetCurrentBranch returns the current branch name

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -167,6 +167,59 @@ func TestBranchExists(t *testing.T) {
 	}
 }
 
+// TestBranchExistsRemoteOnly verifies that a branch existing only as a
+// remote-tracking ref (e.g., a fetched but never-checked-out branch like
+// `ren-bot/foo`) is treated as existing. `git worktree add` will DWIM such a
+// name into a tracking branch, so the pre-check must agree.
+func TestBranchExistsRemoteOnly(t *testing.T) {
+	repoRoot, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Set up a second repo to act as the "remote" and create a branch in it
+	// with a "/" in the name, then fetch it into the test repo as a
+	// remote-tracking ref only (no local branch).
+	remoteDir, err := os.MkdirTemp("", "wt-git-test-remote-*")
+	if err != nil {
+		t.Fatalf("failed to create remote temp dir: %v", err)
+	}
+	remoteDir, err = filepath.EvalSymlinks(remoteDir)
+	if err != nil {
+		t.Fatalf("failed to eval symlinks: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(remoteDir) }()
+
+	for _, c := range [][]string{
+		{"git", "init", "--bare"},
+	} {
+		cmd := exec.Command(c[0], c[1:]...)
+		cmd.Dir = remoteDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("%v failed: %v", c, err)
+		}
+	}
+
+	// Push a branch with a "/" in the name from the test repo to the remote,
+	// then delete the local copy so it exists only as a remote-tracking ref.
+	const remoteBranch = "ren-bot/simplify-bug-delegation-no-owner"
+	for _, c := range [][]string{
+		{"git", "remote", "add", "origin", remoteDir},
+		{"git", "branch", remoteBranch},
+		{"git", "push", "origin", remoteBranch},
+		{"git", "branch", "-D", remoteBranch},
+		{"git", "fetch", "origin"},
+	} {
+		cmd := exec.Command(c[0], c[1:]...)
+		cmd.Dir = repoRoot
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v failed: %v\n%s", c, err, out)
+		}
+	}
+
+	if !BranchExists(repoRoot, remoteBranch) {
+		t.Errorf("expected remote-only branch %q to be reported as existing", remoteBranch)
+	}
+}
+
 func TestGetCurrentBranch(t *testing.T) {
 	repoRoot, cleanup := setupTestRepo(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- `wt create -b <branch>` failed with `branch "..." does not exist` for any branch that only exists as a remote-tracking ref (common for bot-created branches like `ren-bot/foo` that have been fetched but never checked out locally).
- `BranchExists` now checks `refs/heads/<name>` first, then `refs/remotes/<remote>/<name>` for each configured remote — mirroring git's own DWIM behavior in `git worktree add <path> <branch>`, which auto-creates a tracking branch from a unique remote match.
- The `/` in the name in the original report was a red herring; bot branches just happen to use namespacing with `/` and are typically remote-only.

## Test plan
- [x] Added `TestBranchExistsRemoteOnly` — sets up a bare remote, pushes `ren-bot/simplify-bug-delegation-no-owner`, deletes the local copy, fetches, and asserts `BranchExists` returns true.
- [ ] `make test`
- [ ] Manual: `wt create auto-delegation -b <some-remote-only-branch-with-slashes>` succeeds and the new worktree's branch tracks the remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced branch existence detection to now include remote-tracking branches in addition to local branches.

* **Tests**
  * Added test coverage for branches that exist only as remote references.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agarcher/wt/pull/56)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->